### PR TITLE
Only change directory if cookbook path provided

### DIFF
--- a/bin/batali-tk
+++ b/bin/batali-tk
@@ -76,8 +76,8 @@ require 'kitchen/errors'
 
 cwd = Dir.pwd
 begin
-  Dir.chdir(cookbook_path)
+  Dir.chdir(cookbook_path) if cookbook_path
   Kitchen.with_friendly_errors { Kitchen::CLI.start }
 ensure
-  Dir.chdir(cwd)
+  Dir.chdir(cwd) if cookbook_path
 end


### PR DESCRIPTION
This addresses issue #2 where running batali-tk in single cookbook mode
will fail due to attempting to change the working directory without a
destination path set.
